### PR TITLE
PyLinter toegevoegd

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,0 +1,23 @@
+name: Pylint
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pylint
+    - name: Analysing the code with pylint
+      run: |
+        pylint -j 0 $(git ls-files '*.py') --recursive=y --errors-only --disable=C,R


### PR DESCRIPTION
Linter die fouten uit Python3 code haalt. 

Pas deze yaml file aan als je pip packages in je project hebt toegevoegd. Voeg onder run de pip commands toe.

--disable-errors en --disable=C,R zorgen ervoor dat alleen errors uit de code gehaald worden. Als deze 2 flags eruit gehaald worden wordt formattering ook opgemerkt.